### PR TITLE
Use system installed hyperscan

### DIFF
--- a/dp/Makefile
+++ b/dp/Makefile
@@ -98,9 +98,7 @@ endif
 #dpdk-18.02 change build directory structure
 LDFLAGS += -L$(RTE_SRCDIR)/../lib/libsponsdn/x86_64-native-linuxapp-gcc/ -lsponsdn
 
-LDFLAGS += -L$(HYPERSCANDIR)/build/lib
-
-LDFLAGS += -lexpressionutil -lhs -lhs_runtime -lstdc++ -lm -lcrypto
+LDFLAGS += -lhs -lhs_runtime -lstdc++ -lm -lcrypto
 
 LDFLAGS += -lrte_pmd_af_packet
 

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,7 @@
 # Copyright(c) 2017 Intel Corporation
 
 cd $(dirname ${BASH_SOURCE[0]})
+CPUS=${CPUS:-$(nproc)}
 SERVICE=3
 SGX_SERVICE=0
 SERVICE_NAME="Collocated CP and DP"
@@ -208,7 +209,7 @@ install_dpdk()
 	cp -f dpdk-18.02_common_linuxapp "$DPDK_DIR"/config/common_linuxapp
 
 	pushd "$DPDK_DIR"
-	make -j 20 install T="$RTE_TARGET"
+	make -j $CPUS install T="$RTE_TARGET"
 	if [ $? -ne 0 ] ; then
 		echo "Failed to build dpdk, please check the errors."
 		return
@@ -461,12 +462,8 @@ download_hyperscan()
 	pushd hyperscan-4.1.0
 	mkdir build; pushd build
 	cmake -DCMAKE_CXX_COMPILER=c++ ..
-	cmake --build .
-	export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib
-	popd
-	export HYPERSCANDIR=$PWD
-	echo "export HYPERSCANDIR=$PWD" >> ../setenv.sh
-	popd
+	make -j $CPUS install
+	popd; popd;
 }
 
 
@@ -497,16 +494,16 @@ build_ngic()
 {
 	pushd $NGIC_DIR
 	source setenv.sh
-	make -j$(nproc) clean
+	make -j $CPUS clean
 	case "$SERVICE" in
 		1)
-			make -j$(nproc) WHAT="cp" || { echo -e "\nCP: Make failed\n"; }
+			make -j $CPUS WHAT="cp" || { echo -e "\nCP: Make failed\n"; }
 			;;
 		2)
-			make -j$(nproc) WHAT="dp" || { echo -e "\nDP: Make failed\n"; }
+			make -j $CPUS WHAT="dp" || { echo -e "\nDP: Make failed\n"; }
 			;;
 		3)
-			make -j$(nproc) WHAT="cp dp" || { echo -e "\nCP/DP: Make failed\n"; }
+			make -j $CPUS WHAT="cp dp" || { echo -e "\nCP/DP: Make failed\n"; }
 			;;
 		*)
 			echo "Unknown service choice $SERVICE"

--- a/lib/libsponsdn/Makefile
+++ b/lib/libsponsdn/Makefile
@@ -5,17 +5,13 @@ ifeq ($(RTE_SDK),)
 $(error "Please define RTE_SDK environment variable")
 endif
 
-ifeq ($(HYPERSCANDIR),)
-$(error "Please define HYPERSCANDIR environment variable")
-endif
-
 include $(RTE_SDK)/mk/rte.vars.mk
 
 # library name
 LIB = libsponsdn.a
 
 CFLAGS += -O3
-CFLAGS += $(WERROR_FLAGS) -I$(SRCDIR) -I$(HYPERSCANDIR)/src
+CFLAGS += $(WERROR_FLAGS) -I$(SRCDIR)
 
 
 # all source are stored in SRCS-y

--- a/lib/libsponsdn/sponsdn.c
+++ b/lib/libsponsdn/sponsdn.c
@@ -11,7 +11,7 @@
 #include <arpa/inet.h>
 #include <rte_common.h>
 #include <rte_malloc.h>
-#include <hs.h>
+#include <hs/hs.h>
 
 #include <rte_common.h>
 #include <rte_byteorder.h>

--- a/test/sponsdn/Makefile
+++ b/test/sponsdn/Makefile
@@ -20,9 +20,7 @@ CFLAGS += -O3 $(WERROR_FLAGS) -I$(RTE_SRCDIR)/../../lib/libsponsdn/
 
 LDFLAGS += -L$(RTE_SRCDIR)/../../lib/libsponsdn/x86_64-native-linuxapp-gcc/ -lsponsdn
 
-LDFLAGS += -L$(HYPERSCANDIR)/build/lib
-
-LDFLAGS += -lexpressionutil -lhs -lhs_runtime -lstdc++ -lm -lpcap
+LDFLAGS += -lhs -lhs_runtime -lstdc++ -lm -lpcap
 
 
 DEPDIRS-y += ../lib


### PR DESCRIPTION
18.04 provides packaged versions of hyperscan OR
make install places the necessary files in well known locations

Removed any reference to hyperscan directory from Makefiles
Update includes

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>