### PR TITLE
Fix build failing

### DIFF
--- a/cp/main.c
+++ b/cp/main.c
@@ -1142,6 +1142,7 @@ control_plane(void)
 				return;
 			case GTP_DOWNLINK_DATA_NOTIFICATION_ACK:
 				cp_stats.ddn_ack++;
+				return;
 			case GTP_ECHO_REQ:
 				cp_stats.echo++;
 				break;

--- a/cp_dp_api/vepc_cp_dp_api.h
+++ b/cp_dp_api/vepc_cp_dp_api.h
@@ -22,6 +22,7 @@
  * This file contains macros, data structure definitions and function
  * prototypes to describe CP DP APIs.
  */
+#include <stdint.h>
 #include <time.h>
 /**
  * IPv6 address length

--- a/dp/Makefile
+++ b/dp/Makefile
@@ -74,7 +74,11 @@ CFLAGS += -I$(SRCDIR)/../test/simu_cp/nsb
 CFLAGS += -I$(SRCDIR)/pipeline
 CFLAGS += -I$(SRCDIR)/../cp
 CFLAGS += -I$(SRCDIR)/../lib/libsponsdn
-CFLAGS += -I$(SRCDIR)/../dpdk/lib/librte_acl/
+# TODO: This is a hack
+# We should not be looking into private structures
+# Handle this in a patch to DPDK if necessary
+# Check release notes
+CFLAGS += -I$(RTE_SDK)/lib/librte_acl/
 
 # Mandatory CFLAGS, LDFLAGS- DO NOT MODIFY
 # #############################################################

--- a/dp/ether.h
+++ b/dp/ether.h
@@ -25,6 +25,8 @@
 #include <rte_mbuf.h>
 #include <rte_ether.h>
 
+#include "main.h"
+
 #define ETH_TYPE_IPv4 0x0800
 
 /**

--- a/dp/pipeline/epc_arp.c
+++ b/dp/pipeline/epc_arp.c
@@ -293,23 +293,6 @@ struct arp_icmp_route_table_entry {
 	uint32_t nh;
 };
 
-struct ether_addr broadcast_ether_addr = {
-	.addr_bytes[0] = 0xFF,
-	.addr_bytes[1] = 0xFF,
-	.addr_bytes[2] = 0xFF,
-	.addr_bytes[3] = 0xFF,
-	.addr_bytes[4] = 0xFF,
-	.addr_bytes[5] = 0xFF,
-};
-static const struct ether_addr null_ether_addr = {
-	.addr_bytes[0] = 0x00,
-	.addr_bytes[1] = 0x00,
-	.addr_bytes[2] = 0x00,
-	.addr_bytes[3] = 0x00,
-	.addr_bytes[4] = 0x00,
-	.addr_bytes[5] = 0x00,
-};
-
 static void print_ip(int ip)
 {
 	unsigned char bytes[4];
@@ -1622,7 +1605,7 @@ static void
 					(rtp->rtm_table != RT_TABLE_MAIN))
 		        continue;
 
-			i++;
+		    i++;
 		    /* Get attributes of rtp */
 		    rtap = (struct rtattr *) RTM_RTA(rtp);
 

--- a/dp/pipeline/epc_dl.c
+++ b/dp/pipeline/epc_dl.c
@@ -236,12 +236,12 @@ void epc_dl_init(struct epc_dl_params *param, int core, uint8_t in_port_id, uint
     case PGWU:
         if (in_port_id != app.sgi_port && in_port_id != app.s5s8_pgwu_port)
             rte_exit(EXIT_FAILURE, "Wrong MAC configured for S5S8_PGWU/SGI interface\n");
-		break;
+	break;
 
     case SPGWU:
         if (in_port_id != app.sgi_port && in_port_id != app.s1u_port)
             rte_exit(EXIT_FAILURE, "Wrong MAC configured for S1U/SGI interface\n");
-	    break;
+	break;
 
     default:
         rte_exit(EXIT_FAILURE, "Invalid DP type(SPGW_CFG).\n");


### PR DESCRIPTION
- Fixed gcc warnings
  - misleading indentation warning
  - remove unused null_ether_addr broadcast_ether_addr
- Fixed the include to use RTE_SDK instead of assuming DPDK in root
- Fixed 1 and 3 from https://github.com/omec-project/ngic-rtc/issues/16#issuecomment-465435976

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>