### PR TITLE
Compile libgtpv2c as static library

### DIFF
--- a/cp/Makefile
+++ b/cp/Makefile
@@ -72,7 +72,7 @@ ifeq ($(CONFIG_RTE_TOOLCHAIN_GCC),y)
 CFLAGS_controlplane.o += -Wno-return-type
 endif
 
-LDLIBS += -L$(LIBGTPV2C_ROOT)/lib -lgtpv2c
+LDLIBS += -L$(LIBGTPV2C_ROOT)/build -lgtpv2c
 
 LDLIBS += -lpcap
 

--- a/libgtpv2c/Makefile
+++ b/libgtpv2c/Makefile
@@ -1,52 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright(c) 2017 Intel Corporation
 
-
-ROOT=.
-
-CC := gcc
-
-TARGET_DIR := $(ROOT)/lib
-
-SRCDIR := $(ROOT)/src
-TARGET := libgtpv2c.so
-BUILDDIR := $(ROOT)/obj
-
-SRCEXT := c
-
-SOURCES := $(shell find $(SRCDIR) -type f -name '*.$(SRCEXT)')
-
-OBJECTS := $(patsubst $(SRCDIR)/%,$(BUILDDIR)/%,$(SOURCES:.$(SRCEXT)=.o))
-
-CFLAGS +=  -fPIC -Wall
-
-ifeq ($(DEBUG),1)
-	CFLAGS += -g3
-else
-	CFLAGS += -O3
+ifeq ($(RTE_SDK),)
+$(error "Please define RTE_SDK environment variable")
 endif
 
-INCS := -I$(ROOT)/include
-LIB_PATH := 
-LIBS := 
+include $(RTE_SDK)/mk/rte.vars.mk
 
-LFLAGS := -shared
+# library name
+LIB = libgtpv2c.a
 
-$(TARGET_DIR)/$(TARGET): $(OBJECTS)
-	@echo " Linking..."
-	@mkdir -p $(BUILDDIR)
-	@mkdir -p $(TARGET_DIR)
+CFLAGS += -O3
+CFLAGS += $(WERROR_FLAGS) -I$(SRCDIR)/include
 
-	$(CC) $(LFLAGS) $^ -o $(TARGET_DIR)/$(TARGET) $(LIB_PATH) $(LIBS)
+# all source are stored in SRCS-y
+SRCS-y += $(wildcard $(SRCDIR)/src/*.c)
 
-$(BUILDDIR)/%.o: $(SRCDIR)/%.$(SRCEXT)
-	@mkdir -p $(BUILDDIR)
-	@echo " $(CC) $(CFLAGS) $(INCS) -c -o $@ $<"; $(CC) $(CFLAGS) $(INCS) -c -o $@ $<
-
-all:$(TARGET)
-
-clean:
-	@echo " Cleaning...";
-	@echo " $(RM) -r $(BUILDDIR) $(TARGET_DIR)"; $(RM) -r $(BUILDDIR) $(TARGET_DIR)
-
-.PHONY: clean
+include $(RTE_SDK)/mk/rte.extlib.mk


### PR DESCRIPTION
Makes the build consistent with rest of the repo
Reduces number of build artifacts to deal with by one

Fixes: #26

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>