### PR TITLE
Adding AF_PACKET socket interface to the kernel

### DIFF
--- a/INSTALL.MD
+++ b/INSTALL.MD
@@ -599,6 +599,33 @@ cd  dev_scripts
 ```
 
 f. Then start the traffic generator and MME if applicable.
+
+You can now run ngic without kni support using the following guidelines:
+
+a. Repeat step (a) from previous subsection to setup dpdk driver.
+
+b. Enable `-DUSE_AF_PACKET` macro in [`dp/Makefile`](dp/Makefile). Then add the mac addresses of
+port0 and port1 in [`config/dp_config.cfg`](config/dp_config.cfg) to run `ngic_dataplane`.
+
+```shell
+cd dp
+Edit run.sh to add coremask
+```
+
+c. Run following to create veth pairs of S1U/SGI interfaces.
+
+```shell
+sudo ./setup_af_ifaces.sh
+```
+
+d. Run dp.
+
+```shell
+cd dp
+./run.sh
+```
+
+e. Update cp_config.cfg with required parameters.
 #### 3.5 Standalone Virtualization:
 Dataplane has been tested with SRIOV and OVS with SIMU_CP configuration:
 

--- a/delete_af_ifaces.sh
+++ b/delete_af_ifaces.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+set -o nounset
+
+# Move to script directory
+cd $(dirname ${BASH_SOURCE[0]})
+
+# Load iface parameters
+source config/dp_config.cfg
+
+SUDO=''
+[[ $EUID -ne 0 ]] && SUDO=sudo
+
+# delete ul interface
+$SUDO ip link delete $UL_IFACE || true
+
+# delete dl interface
+$SUDO ip link delete $DL_IFACE || true

--- a/dp/Makefile
+++ b/dp/Makefile
@@ -150,6 +150,9 @@ endif
 CFLAGS += -O3
 #CFLAGS += -g -O0
 
+# Un-comment to enable USE_AF_PACKET
+#CFLAGS += -DUSE_AF_PACKET
+
 #un-comment below line to remove all log level for preformance testing.
 CFLAGS += -DPERF_TEST
 

--- a/dp/Makefile
+++ b/dp/Makefile
@@ -152,6 +152,10 @@ CFLAGS += -O3
 
 # Un-comment to enable USE_AF_PACKET
 #CFLAGS += -DUSE_AF_PACKET
+ifneq (,$(findstring USE_AF_PACKET, $(CFLAGS), $(EXTRA_CFLAGS)))
+	CFLAGS += -I/usr/include/libnl3
+	LDFLAGS += -lmnl
+endif
 
 #un-comment below line to remove all log level for preformance testing.
 CFLAGS += -DPERF_TEST

--- a/dp/main.h
+++ b/dp/main.h
@@ -289,6 +289,20 @@ extern uint32_t nb_ports;
 
 extern struct kni_port_params *kni_port_params_array[RTE_MAX_ETHPORTS];
 
+#ifdef USE_AF_PACKET
+/**
+ * Interface to burst rx and enqueue in to kernel
+ */
+void
+kern_packet_ingress(int portid, struct rte_mbuf *pkts_burst[PKT_BURST_SZ], unsigned nb_rx);
+
+/**
+ * Interface to relay tx traffic out of the kernel and into the outgoing NIC
+ */
+void
+kern_packet_egress(int portid);
+#endif
+
 /**
  * Interface to burst rx and enqueue mbufs into rx_q
  */

--- a/dp/main.h
+++ b/dp/main.h
@@ -291,6 +291,12 @@ extern struct kni_port_params *kni_port_params_array[RTE_MAX_ETHPORTS];
 
 #ifdef USE_AF_PACKET
 /**
+ * Initialize libmnl netlink subsystem
+ */
+void
+init_mnl();
+
+/**
  * Interface to burst rx and enqueue in to kernel
  */
 void
@@ -428,6 +434,18 @@ extern struct app_params app;
 
 /** ethernet addresses of ports */
 struct ether_addr ports_eth_addr[RTE_MAX_ETHPORTS];
+
+#ifdef USE_AF_PACKET
+typedef struct dp_port_info {
+	struct ether_addr *eth_addr;
+	uint8_t ifup_state;
+	uint16_t mtu_size;
+	uint8_t promisc_state;
+} dp_port_info;
+
+struct dp_port_info dp_ports[RTE_MAX_ETHPORTS];
+extern struct mnl_socket *mnl_sock;
+#endif
 
 /** ethernet addresses of ports */
 extern struct ether_addr ports_eth_addr[];

--- a/dp/pipeline/epc_arp.c
+++ b/dp/pipeline/epc_arp.c
@@ -1952,6 +1952,7 @@ epc_arp_init(void)
 #endif	/* STATIC_ARP */
 }
 
+#ifndef USE_AF_PACKET
 /* Burst rx from kni interface and enqueue rx pkts in ring */
 static void *handle_kni_process(__rte_unused void *arg)
 {
@@ -1960,6 +1961,7 @@ static void *handle_kni_process(__rte_unused void *arg)
 	}
 	return NULL; //GCC_Security flag
 }
+#endif
 
 void epc_arp(__rte_unused void *arg)
 {
@@ -1969,7 +1971,9 @@ void epc_arp(__rte_unused void *arg)
 			rte_pipeline_flush(myP);
 			param->flush_count = 0;
 		}
+#ifndef USE_AF_PACKET
 		handle_kni_process(NULL);
+#endif
 #ifdef NGCORE_SHRINK
 #ifdef STATS
 	epc_stats_core();

--- a/dp/pipeline/epc_arp.h
+++ b/dp/pipeline/epc_arp.h
@@ -168,4 +168,10 @@ int arp_qunresolved_ulpkt(struct arp_entry_data *arp_data,
 int arp_qunresolved_dlpkt(struct arp_entry_data *arp_data,
 				struct rte_mbuf *m, uint8_t portid);
 
+#ifdef USE_AF_PACKET
+int
+kni_change_mtu(uint16_t port_id, unsigned int new_mtu);
+
+int kni_config_mac_address(uint16_t port_id, uint8_t mac_addr[]);
+#endif
 #endif /*__EPC_ARP_ICMP_H__ */

--- a/dp/pipeline/epc_dl.c
+++ b/dp/pipeline/epc_dl.c
@@ -159,8 +159,12 @@ static int epc_dl_port_in_ah(struct rte_pipeline *p,
 
 	if (dl_nkni_pkts) {
 		RTE_LOG(DEBUG, DP, "KNI: DL send pkts to kni\n");
+#ifdef USE_AF_PACKET
+		kern_packet_ingress(SGI_PORT_ID, kni_pkts_burst, dl_nkni_pkts);
+#else
 		kni_ingress(kni_port_params_array[SGI_PORT_ID],
 				kni_pkts_burst, dl_nkni_pkts);
+#endif
 
 	}
 #ifdef STATS
@@ -393,8 +397,11 @@ void epc_dl(void *args)
 	 *  Then analyzes it and calls the specific actions for the specific requests.
 	 *  Finally constructs the response mbuf and puts it back to the resp_q.
 	 */
+#ifdef USE_AF_PACKET
+	kern_packet_egress(S1U_PORT_ID);
+#else /* KNI MODE */
 	rte_kni_handle_request(kni_port_params_array[SGI_PORT_ID]->kni[0]);
-
+#endif
 	uint32_t queued_cnt = rte_ring_count(shared_ring[S1U_PORT_ID]);
 	if (queued_cnt) {
 		struct rte_mbuf *pkts[queued_cnt];

--- a/dp/pipeline/epc_packet_framework.h
+++ b/dp/pipeline/epc_packet_framework.h
@@ -33,6 +33,9 @@ extern uint64_t num_dns_processed;
 /**
  * S1U port id.
  */
+#ifdef USE_AF_PACKET
+#define	S1U_PORT_VETH_ID	S1U_PORT_ID + NUM_SPGW_PORTS
+#endif
 #define S1U_PORT_ID   0
 #define WEST_PORT_ID   0
 
@@ -42,6 +45,9 @@ extern uint64_t num_dns_processed;
 
 #define SGI_PORT_ID   1
 #define EAST_PORT_ID   1
+#ifdef USE_AF_PACKET
+#define	SGI_PORT_VETH_ID	SGI_PORT_ID + NUM_SPGW_PORTS
+#endif
 
 #define DL_RINGS_THRESHOLD 32
 

--- a/dp/pipeline/epc_ul.c
+++ b/dp/pipeline/epc_ul.c
@@ -184,8 +184,12 @@ static int epc_ul_port_in_ah(struct rte_pipeline *p,
 
 	if (ul_nkni_pkts) {
 		RTE_LOG(DEBUG, DP, "KNI: UL send pkts to kni\n");
+#ifdef USE_AF_PACKET
+		kern_packet_ingress(S1U_PORT_ID, kni_pkts_burst, ul_nkni_pkts);
+#else
 		kni_ingress(kni_port_params_array[S1U_PORT_ID],
 				kni_pkts_burst, ul_nkni_pkts);
+#endif
 	}
 
 #ifdef STATS
@@ -417,7 +421,11 @@ void epc_ul(void *args)
 	 *  Then analyzes it and calls the specific actions for the specific requests.
 	 *  Finally constructs the response mbuf and puts it back to the resp_q.
 	 */
+#ifdef USE_AF_PACKET
+	kern_packet_egress(SGI_PORT_ID);
+#else /* KNI mode */
 	rte_kni_handle_request(kni_port_params_array[S1U_PORT_ID]->kni[0]);
+#endif
 
 	uint32_t queued_cnt = rte_ring_count(shared_ring[SGI_PORT_ID]);
 	if (queued_cnt) {

--- a/install.sh
+++ b/install.sh
@@ -133,7 +133,8 @@ get_agreement_download()
 	echo "8.  hyperscan"
 	echo "9.  curl"
 	echo "10. openssl-dev"
-	echo "11. and other library dependencies"
+	echo "11. libmnl-dev"
+	echo "12. and other library dependencies"
 	while true; do
 		read -p "We need download above mentioned package. Press (y/n) to continue? " yn
 		case $yn in
@@ -162,7 +163,8 @@ install_libs()
 	sudo apt-get update
 	sudo apt-get -y install curl build-essential linux-headers-$(uname -r) \
 		git unzip libpcap0.8-dev gcc libjson0-dev make libc6 libc6-dev \
-		g++-multilib libzmq3-dev libcurl4-openssl-dev libssl-dev python-pip
+		g++-multilib libzmq3-dev libcurl4-openssl-dev libssl-dev python-pip \
+		libmnl-dev
 
 	pip install zmq
 

--- a/interface/interface.c
+++ b/interface/interface.c
@@ -40,6 +40,9 @@
 #include "zmq_push_pull.h"
 #include "cp.h"
 #endif
+#ifdef USE_AF_PACKET
+#include <libmnl/libmnl.h>
+#endif
 
 #include "main.h"
 
@@ -1216,6 +1219,9 @@ void sig_handler(int signo)
 		print_perf_statistics();
 #endif /* AUTO_ANALYSIS */
 #endif /* TIMER_STATS */
+#ifdef USE_AF_PACKET
+		mnl_socket_close(mnl_sock);
+#endif
 		rte_exit(EXIT_SUCCESS, "received SIGINT\n");
 	}
 	else if (signo == SIGSEGV)

--- a/setup_af_ifaces.sh
+++ b/setup_af_ifaces.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Move to script directory
+cd $(dirname ${BASH_SOURCE[0]})
+
+# Load iface parameters
+source config/dp_config.cfg
+
+calc_cidrmask() {
+    local CIDR_MASK=0
+    local DOTTED_MASK=$1
+    for octet in $(echo $DOTTED_MASK | sed 's/\./ /g'); do
+	binbits=$(echo "obase=2; ibase=10; ${octet}"| bc | sed 's/0//g')
+	let CIDR_MASK+=${#binbits}
+    done
+
+    echo $CIDR_MASK
+}
+
+SUDO=''
+[[ $EUID -ne 0 ]] && SUDO=sudo
+
+$SUDO ip link add $UL_IFACE type veth peer name l_$UL_IFACE
+$SUDO ip link add $DL_IFACE type veth peer name l_$DL_IFACE
+$SUDO ip link set $UL_IFACE up
+$SUDO ip link set $DL_IFACE up
+$SUDO ip link set l_$UL_IFACE up
+$SUDO ip link set l_$DL_IFACE up
+$SUDO ip link set dev $UL_IFACE address $S1U_MAC
+$SUDO ip link set dev $DL_IFACE address $SGI_MAC
+
+CIDR_MASK=$(calc_cidrmask $S1U_MASK)
+$SUDO ip addr add $S1U_IP/$CIDR_MASK dev $UL_IFACE
+
+CIDR_MASK=$(calc_cidrmask $SGI_MASK)
+$SUDO ip addr add $SGI_IP/$CIDR_MASK dev $DL_IFACE
+
+ip route


### PR DESCRIPTION
This provides an alternative to the KNI module. We create veth
peer interfaces to pipe control traffic in to the kernel stack.
Link updated related functions are now also added.

Fixes: #3 

Signed-off-by: Muhammad Asim Jamshed <muhammad.jamshed@intel.com>