### PR TITLE
Add ability to resolve names in addition to IP

### DIFF
--- a/dp/config.c
+++ b/dp/config.c
@@ -9,6 +9,10 @@
 #include <sys/stat.h>
 #include <errno.h>
 #include <string.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <unistd.h>
 
 #include <rte_ethdev.h>
 #include <rte_kni.h>
@@ -221,6 +225,41 @@ static inline int parse_ether_addr(struct ether_addr *hwaddr, const char *str)
 			(size_t *) &hwaddr->addr_bytes[4],
 			(size_t *) &hwaddr->addr_bytes[5]);
 	return 1;
+}
+
+#define SLEEP_SEC 5
+#define NUM_RETRIES 10
+
+/**
+ * Parses c-string containing dotted decimal ipv4 or hostname and stores the
+ *   value within the in_addr type
+ *
+ * @param optarg
+ *   c-string containing dotted decimal ipv4 address or hostname
+ * @param addr
+ *   destination of parsed IP string
+ */
+void
+parse_arg_host(const char *optarg, struct in_addr *addr)
+{
+	int ret = -1, retries = NUM_RETRIES;
+	struct addrinfo hints, *servinfo;
+	memset(&hints, 0, sizeof hints);
+	hints.ai_family = AF_INET;
+
+	/*NUM_RETRIES with SLEEP_SEC in between to resolve the name*/
+	while(retries-- > 0 && (ret = getaddrinfo(optarg, NULL, &hints, &servinfo) !=0)){
+		RTE_LOG(ERR, DP, "Unable to resolve %s. Retrying in %d sec\n",
+					optarg, SLEEP_SEC);
+		sleep(SLEEP_SEC);
+	}
+
+	if(ret)
+		rte_exit(EXIT_FAILURE, "Unable to resolve %s. Exiting\n", optarg);
+
+	struct sockaddr_in *h = (struct sockaddr_in *) servinfo->ai_addr;
+	memcpy(addr, &h->sin_addr, sizeof(struct in_addr));
+	freeaddrinfo(servinfo);
 }
 
 static inline void set_unused_lcore(int *core, uint64_t *used_coremask)

--- a/interface/interface.h
+++ b/interface/interface.h
@@ -21,6 +21,8 @@
 #include "vepc_cp_dp_api.h"
 #include "vepc_udp.h"
 
+extern void parse_arg_host(const char *optarg, struct in_addr *addr);
+
 uint8_t zmq_comm_switch;
 
 #ifdef SDN_ODL_BUILD


### PR DESCRIPTION
Changed the function name from parse_arg_ip to parse_arg_host
Used getaddrinfo to be able to resolve names and dotted decimal IP
Duplication in DP is needed since interface.c is common

Fixes: #2

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>