### PR TITLE
Dump the stack on catching SIGSEGV

### DIFF
--- a/cp/main.c
+++ b/cp/main.c
@@ -448,7 +448,8 @@ init_cp(void)
 
 	if (signal(SIGINT, sig_handler) == SIG_ERR)
 		rte_exit(EXIT_FAILURE, "Error:can't catch SIGINT\n");
-
+	if (signal(SIGSEGV, sig_handler) == SIG_ERR)
+		rte_exit(EXIT_FAILURE, "Error:can't catch SIGSEGV\n");
 
 #ifndef SDN_ODL_BUILD
 #ifdef CP_DP_TABLE_CONFIG

--- a/dp/main.c
+++ b/dp/main.c
@@ -45,6 +45,8 @@ int main(int argc, char **argv)
 
 	if (signal(SIGINT, sig_handler) == SIG_ERR)
 		rte_exit(EXIT_FAILURE, "Error:can't catch SIGINT\n");
+	if (signal(SIGSEGV, sig_handler) == SIG_ERR)
+		rte_exit(EXIT_FAILURE, "Error:can't catch SIGSEGV\n");
 	argc -= ret;
 	argv += ret;
 

--- a/interface/interface.c
+++ b/interface/interface.c
@@ -31,6 +31,7 @@
 #include <rte_malloc.h>
 #include <rte_jhash.h>
 #include <rte_cfgfile.h>
+#include <rte_debug.h>
 
 #include "interface.h"
 #include "util.h"
@@ -1221,5 +1222,7 @@ void sig_handler(int signo)
 #endif /* TIMER_STATS */
 		rte_exit(EXIT_SUCCESS, "received SIGINT\n");
 	}
+	else if (signo == SIGSEGV)
+		rte_panic("received SIGSEGV\n");
 }
 


### PR DESCRIPTION
Currently we do not have any indication where the programs crash.
Add SIGSEGV handler that dumps the stack as using rte_panic.

Fixes: #24 

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>