### PR TITLE
Adding support for EXTRA_CFLAGS in cp & dp Makefiles

### DIFF
--- a/cp/Makefile
+++ b/cp/Makefile
@@ -79,20 +79,20 @@ LDLIBS += -lpcap
 # ngic-cp application options CFLAGS
 # #############################################################
 #validate both SDN_ODL_BUILD and ZMQ_COMM flag are not defined
-ifneq (,$(findstring SDN_ODL_BUILD, $(CFLAGS)))
-ifneq (,$(findstring ZMQ_COMM, $(CFLAGS)))
+ifneq (,$(findstring SDN_ODL_BUILD, $(CFLAGS), $(EXTRA_CFLAGS)))
+ifneq (,$(findstring ZMQ_COMM, $(CFLAGS), $(EXTRA_CFLAGS)))
 $(error "Both "SDN_ODL_BUILD" and "ZMQ_COMM" flags are defined. Exiting..")
 endif
 endif
 
 #For SDN NB interface enable SDN_ODL_BUILD OR SDN_ONOS_BUILD not both
-ifneq (,$(findstring SDN_ODL_BUILD, $(CFLAGS)))
+ifneq (,$(findstring SDN_ODL_BUILD, $(CFLAGS), $(EXTRA_CFLAGS)))
 	SRCS-y += nb.c
 	LDLIBS += -ljson-c
 	LDLIBS += -lcurl
 endif
 
-ifneq (,$(findstring ZMQ_COMM, $(CFLAGS)))
+ifneq (,$(findstring ZMQ_COMM, $(CFLAGS), $(EXTRA_CFLAGS)))
 	SRCS-y += cp_sync.c
 	SRCS-y += ../interface/zmq/zmq_push_pull.c
 	LDFLAGS += -L/usr/local/lib -lzmq
@@ -118,7 +118,7 @@ CFLAGS_config.o := -D_GNU_SOURCE
 #Note: Req and Resp timer stats is not supported for CP <--> DP direct comm over UDP.
 #CFLAGS += -DSYNC_STATS
 
-ifneq (,$(findstring SYNC_STATS, $(CFLAGS)))
+ifneq (,$(findstring SYNC_STATS, $(CFLAGS), $(EXTRA_CFLAGS)))
 	SRCS-y += stats_sync.c
 endif
 

--- a/dp/Makefile
+++ b/dp/Makefile
@@ -105,7 +105,7 @@ LDFLAGS += -lpcap
 # ngic-dp application options CFLAGS
 # #############################################################
 # ASR- Shrink pipeline COREs for Run to Completion (rtc) model
-ifneq (,$(findstring NGCORE_SHRINK, $(CFLAGS)))
+ifneq (,$(findstring NGCORE_SHRINK, $(CFLAGS), $(EXTRA_CFLAGS)))
         SRCS-y += ddn.c
         SRCS-y += pipeline/epc_ul.c
         SRCS-y += pipeline/epc_dl.c
@@ -118,13 +118,13 @@ else
 endif
 
 #validate both SDN_ODL_BUILD and ZMQ_COMM flag are not defined
-ifneq (,$(findstring SDN_ODL_BUILD, $(CFLAGS)))
-ifneq (,$(findstring ZMQ_COMM, $(CFLAGS)))
+ifneq (,$(findstring SDN_ODL_BUILD, $(CFLAGS), $(EXTRA_CFLAGS)))
+ifneq (,$(findstring ZMQ_COMM, $(CFLAGS), $(EXTRA_CFLAGS)))
 $(error "Both "SDN_ODL_BUILD" and "ZMQ_COMM" flags are defined. Exiting..")
 endif
 endif
 
-ifneq (,$(findstring SDN_ODL_BUILD, $(CFLAGS)))
+ifneq (,$(findstring SDN_ODL_BUILD, $(CFLAGS), $(EXTRA_CFLAGS)))
 	SRCS-y += ../interface/zmq/zmqsub.c
 	SRCS-y += ../interface/zmq/zmqpub.c
 	LDFLAGS += -L/usr/local/lib -lzmq
@@ -137,7 +137,7 @@ ifeq ($(SGX_BUILD), 1)
 	LDFLAGS += -lssl
 endif
 
-ifneq (,$(findstring ZMQ_COMM, $(CFLAGS)))
+ifneq (,$(findstring ZMQ_COMM, $(CFLAGS), $(EXTRA_CFLAGS)))
 	SRCS-y += ../interface/zmq/zmq_push_pull.c
 	LDFLAGS += -L/usr/local/lib -lzmq
 endif
@@ -162,7 +162,7 @@ CFLAGS += -DPERF_TEST
 #CFLAGS += -DDEL_SESS_REQ
 
 # VS- Used CP counters for maintain simulator stats.
-ifneq (,$(findstring SIMU_CP, $(CFLAGS)))
+ifneq (,$(findstring SIMU_CP, $(CFLAGS), $(EXTRA_CFLAGS)))
         SRCS-y += ../cp/cp_stats.c
 endif
 


### PR DESCRIPTION
With this patch, users can set macros using command-line arguments during compilation. Using just CFLAGS for this purpose breaks the compilation process. This solves the issue reported by
github/omec-project/omec-project-ci/#16.

Signed-off-by: Muhammad Asim Jamshed <muhammad.jamshed@intel.com>