### PR TITLE
Clean up references to ng-core_cfg.mk

### DIFF
--- a/INSTALL.MD
+++ b/INSTALL.MD
@@ -212,11 +212,9 @@ direction of messages. Listed below the diagram is the descriptions of
 [Components](./INSTALL.MD#2-4-1-components) and
 [Interfaces](./INSTALL.MD#2-4-2-interfaces).
 
-To disable CP to DP direct communication over ZMQ, disable ZMQ_COMM CFLAG in
-`ng-core_cfg.mk`. In this case ZMQ push/pull model is used.
-
-ZMQ_COMM flag (ZMQ Push Pull) is enabled by default in config/ng-core_cfg.mk
-Thus, ZMQ(tcp) is the default mode of communication between CP & DP in NGIC.
+To enable CP to DP direct communication over ZMQ, define ZMQ_COMM CFLAG in
+[`custom-cp.mk`](cp/custom-cp.mk) and [`custom-dp.mk`](dp/custom-dp.mk). In this
+case ZMQ push/pull model is used.
 
 ```text
 +-------------------------------------------------------------------------------+
@@ -253,8 +251,7 @@ Thus, ZMQ(tcp) is the default mode of communication between CP & DP in NGIC.
 ##### 2.4.1 Components
 
 - FPC - SDN Controller: Interfaces contained within this component are used
-    only when NGIC is built with the `DSDN_ODL_BUILD` CFLAG set in
-    `ng-core_cfg.mk`.
+    only when NGIC is built with the `DSDN_ODL_BUILD` CFLAG set.
 
 - ZMQ FORWARDER: the instance of the forwarder_device.py script. ***This
     component should be co-located with the FPC Karaf component.***
@@ -568,10 +565,10 @@ a. Setup 10G ports for VNF to run:
 
 b. If ZMQ_COMM flag is enabled, start ZMQ Streamer before running DP and CP
 
-  If ZMQ_COMM flag is enabled in the config file ng-core_cfg.mk, then we need to start the
-  ZMQ streamer before running DP & CP. This can be done via the following script run.
-  NOTE: The script needs to be started either on CP or DP or any other systems and update
-        interface.cfg accordingly. No need to start on both CP and DP.
+  If ZMQ_COMM flag is enabled, then we need to start the ZMQ streamer before
+  running DP & CP. This can be done via the following script run. NOTE: The
+  script needs to be started either on CP or DP or any other systems and update
+  interface.cfg accordingly. No need to start on both CP and DP.
 
 ```shell
 cd dev_scripts

--- a/config/interface.cfg
+++ b/config/interface.cfg
@@ -7,8 +7,7 @@ zmq_protocol = tcp
 
 ; zmq publisher and subscriber ip:port. To be configured to an available ip
 ; on the FPC Host. The port values are defined by the FPC Project.
-; These values are unused when DSDN_ODL_BUILD CFLAG not defined in
-; ng-core_cfg.mk
+; These values are unused when DSDN_ODL_BUILD CFLAG not defined
 zmq_sub_ip = 192.168.126.60
 zmq_sub_port = 5560
 zmq_pub_ip = 192.168.126.80
@@ -42,16 +41,14 @@ cp_comm_port = 21
 
 ; FPC ip:port: To be configured to an available IP of FPC host. The fpc_port
 ; is defined by the FPC project.
-; These values are unused when DSDN_ODL_BUILD CFLAG not defined in
-; ng-core_cfg.mk
+; These values are unused when DSDN_ODL_BUILD CFLAG not defined
 fpc_ip = 192.168.125.70
 fpc_port = 8070
 fpc_topology_port = 8181
 
 ; The CP Northbound server ip:port: May be configured to any available ip:port
 ; on the CP Host.
-; These values are unused when DSDN_ODL_BUILD CFLAG not defined in
-; ng-core_cfg.mk
+; These values are unused when DSDN_ODL_BUILD CFLAG not defined
 cp_nb_ip = 192.168.125.60
 cp_nb_port = 9997
 

--- a/dev_scripts/wokni/Makefile_wkni
+++ b/dev_scripts/wokni/Makefile_wkni
@@ -11,7 +11,7 @@ MAKEFLAGS += -j
 RTE_TARGET ?= x86_64-native-linuxapp-gcc
 
 include $(RTE_SDK)/mk/rte.vars.mk
-include $(NG_CORE)/config/ng-core_cfg.mk
+include $(dir $(realpath $(firstword $(MAKEFILE_LIST))))/*.mk
 
 #DIRS-y += pipeline
 # binary name

--- a/dev_scripts/wokni/Makefile_wokni
+++ b/dev_scripts/wokni/Makefile_wokni
@@ -11,7 +11,7 @@ MAKEFLAGS += -j
 RTE_TARGET ?= x86_64-native-linuxapp-gcc
 
 include $(RTE_SDK)/mk/rte.vars.mk
-include $(NG_CORE)/config/ng-core_cfg.mk
+include $(dir $(realpath $(firstword $(MAKEFILE_LIST))))/*.mk
 
 #DIRS-y += pipeline
 # binary name


### PR DESCRIPTION
File ng-core_cfg.mk has been moved to custom-cp/dp.mk in PR #18.
Removing/updating references to the file.

Fixes: #69

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>