### PR TITLE
Update install_rundeps.sh

### DIFF
--- a/install_rundeps.sh
+++ b/install_rundeps.sh
@@ -14,6 +14,7 @@ install_run_cp_deps() {
 install_run_dp_deps() {
 	$SUDO apt-get update && $SUDO apt-get -y install \
 		libhyperscan4 \
+		libmnl0 \
 		libnuma1 \
 		libssl1.1
 }


### PR DESCRIPTION
libmnl runtime library was missing

```
ngic_dataplane: error while loading shared libraries: libmnl.so.0: cannot open shared object file: No such file or directory
```