### PR TITLE
Add --no_veth to disable veth pair support of USE_AF_PACKET

### DIFF
--- a/dp/config.c
+++ b/dp/config.c
@@ -335,6 +335,7 @@ parse_config_args(struct app_params *app, int argc, char **argv)
 		{"kni_portmask", required_argument, 0, 'p'},
 		{"ul_iface", required_argument, 0, 'b'},
 		{"dl_iface", required_argument, 0, 'c'},
+		{"no_veth", optional_argument, 0, 't'},
 		{NULL, 0, 0, 0}
 	};
 
@@ -621,6 +622,9 @@ parse_config_args(struct app_params *app, int argc, char **argv)
 			memcpy(app->dl_iface_name, optarg, RTE_KNI_NAMESIZE);
 			break;
 
+		case 't':
+			app->no_veth = 1;
+			break;
 		default:
 			dp_print_usage();
 			return -1;

--- a/dp/init.c
+++ b/dp/init.c
@@ -217,10 +217,18 @@ init_af_socks()
 
 		switch (port) {
 		case S1U_PORT_VETH_ID:
-			ifidx = if_nametoindex(app.ul_iface_name);
+			if (app.no_veth == 0) {
+				ifidx = if_nametoindex(app.ul_iface_name);
+			} else {
+				strcpy(peer_ifname, app.ul_iface_name);
+			}
 			break;
 		case SGI_PORT_VETH_ID:
-			ifidx = if_nametoindex(app.dl_iface_name);
+			if (app.no_veth == 0) {
+				ifidx = if_nametoindex(app.dl_iface_name);
+			} else {
+				strcpy(peer_ifname, app.dl_iface_name);
+			}
 			break;
 		default:
 			rte_panic("Unknown port_id: %hu\n", port);
@@ -229,8 +237,11 @@ init_af_socks()
 		if (ifidx == 0)
 			rte_panic("Failed to retrieve ifidx for port: %hu\n", port);
 		/* create full string for net_af_packet */
-		if (if_indextoname(ifidx - 1, peer_ifname) == NULL)
-			rte_panic("Failed to retrieve interface name of peer veth\n");
+		if (app.no_veth == 0) {
+			if (if_indextoname(ifidx - 1, peer_ifname) == NULL)
+				rte_panic("Failed to retrieve interface name of peer veth\n");
+		}
+
 		sprintf(dev_name, "net_af_packet%d,iface=%s", port, peer_ifname);
 
 		retval = rte_eth_dev_attach(dev_name, &port);

--- a/dp/main.h
+++ b/dp/main.h
@@ -409,6 +409,7 @@ struct app_params {
 	uint32_t ports_mask;
 	char ul_iface_name[MAX_LEN];
 	char dl_iface_name[MAX_LEN];
+	uint32_t no_veth;
 	enum dp_config spgw_cfg;
 	struct ether_addr s1u_ether_addr;		/* s1u mac addr */
 	struct ether_addr s5s8_sgwu_ether_addr;	/* s5s8_sgwu mac addr */


### PR DESCRIPTION
By default when compiled with USE_AF_PACKET, the code will assume
that ul_iface and dl_iface refer to veth pairs. This new option
disables that assumption and just uses the supplied interface names.

This is useful when running in a container and want to use vdev interfaces for S1U/SGi but
but not KNI.

Signed-off-by: Nikolay Nikolaev <nnikolay@vmware.com>