### PR TITLE
Fixed endianness orders for a few messages.

### DIFF
--- a/cp/cp_config.c
+++ b/cp/cp_config.c
@@ -353,8 +353,8 @@ fetch_s1u_sgw_ip(uint32_t dpId)
 		}
 	}
 
-	rte_panic("Could not find s1u ip address for dpid: %u\n", dpId);
-	rte_exit(EXIT_FAILURE, "Could not find s1u ip address for dpid: %u\n", dpId);
+	rte_panic("Could not find s1u ip address for an unregistered DP\n");
+
 	/* control should never reach here */
 	RTE_SET_USED(a);
 	return a;

--- a/cp/gtpv2c_messages/create_bearer.c
+++ b/cp/gtpv2c_messages/create_bearer.c
@@ -185,6 +185,11 @@ process_create_bearer_response(gtpv2c_header *gtpv2c_rx)
 	session.sess_id = SESS_ID(create_bearer_rsp.context->s11_sgw_gtpc_teid,
 				create_bearer_rsp.ded_bearer->eps_bearer_id);
 
+	RTE_LOG_DP(INFO, CP, "Sending session create bearer request with ue IPv4 addr: ");
+	RTE_LOG_DP(INFO, CP, "%d.%d.%d.%d", ((session.ue_addr.u.ipv4_addr >> 24) & 0xFF),
+		((session.ue_addr.u.ipv4_addr >> 16) & 0xFF),
+		((session.ue_addr.u.ipv4_addr >> 8) & 0xFF),
+		((session.ue_addr.u.ipv4_addr & 0xFF)));
 	/* TODO : new bearer should be created on the same DP. Pull the dpId from user context and 
 	* then send the bearer create to the same dp id. 	
 	*/

--- a/cp/gtpv2c_messages/create_session.c
+++ b/cp/gtpv2c_messages/create_session.c
@@ -549,6 +549,11 @@ process_create_session_request(gtpv2c_header *gtpv2c_rx,
 	session.sess_id = SESS_ID(context->s11_sgw_gtpc_teid,
 						bearer->eps_bearer_id);
 
+	RTE_LOG_DP(INFO, CP, "Sending session create request with ue IPv4 addr: ");
+	RTE_LOG_DP(INFO, CP, "%d.%d.%d.%d", ((session.ue_addr.u.ipv4_addr >> 24) & 0xFF),
+		((session.ue_addr.u.ipv4_addr >> 16) & 0xFF),
+		((session.ue_addr.u.ipv4_addr >> 8) & 0xFF),
+		((session.ue_addr.u.ipv4_addr & 0xFF)));
 	if (session_create(dp_id, session) < 0) {
 #if defined(ZMQ_COMM) && defined(MULTI_UPFS)
 		RTE_LOG_DP(INFO, CP, "Bearer session create failed!\n");
@@ -565,6 +570,11 @@ process_create_session_request(gtpv2c_header *gtpv2c_rx,
 		for (i = 0; i < num_adc_rules; ++i)
 			        session.adc_rule_id[i] = adc_rule_id[i];
 
+	RTE_LOG_DP(INFO, CP, "Sending session modify request with ue IPv4 addr: ");
+	RTE_LOG_DP(INFO, CP, "%d.%d.%d.%d", ((session.ue_addr.u.ipv4_addr >> 24) & 0xFF),
+		((session.ue_addr.u.ipv4_addr >> 16) & 0xFF),
+		((session.ue_addr.u.ipv4_addr >> 8) & 0xFF),
+		((session.ue_addr.u.ipv4_addr & 0xFF)));
 		if (session_modify(dp_id, session) < 0) {
 #if defined(ZMQ_COMM) && defined(MULTI_UPFS)
 			RTE_LOG_DP(INFO, CP, "Bearer session create CIOT implicit modify failed !!!\n");

--- a/cp/gtpv2c_messages/delete_bearer.c
+++ b/cp/gtpv2c_messages/delete_bearer.c
@@ -142,6 +142,11 @@ process_delete_bearer_response(gtpv2c_header *gtpv2c_rx)
 		si.sess_id =
 			SESS_ID(delete_bearer_rsp.context->s11_sgw_gtpc_teid,
 				delete_bearer_rsp.ded_bearer->eps_bearer_id);
+			RTE_LOG_DP(INFO, CP, "Sending session delete bearer request with ue IPv4 addr: ");
+			RTE_LOG_DP(INFO, CP, "%d.%d.%d.%d", ((si.ue_addr.u.ipv4_addr >> 24) & 0xFF),
+				((si.ue_addr.u.ipv4_addr >> 16) & 0xFF),
+				((si.ue_addr.u.ipv4_addr >> 8) & 0xFF),
+				((si.ue_addr.u.ipv4_addr & 0xFF)));
 		session_delete(dp_id, si);
 
 		rte_free(delete_bearer_rsp.ded_bearer);

--- a/cp/gtpv2c_messages/delete_session.c
+++ b/cp/gtpv2c_messages/delete_session.c
@@ -117,13 +117,18 @@ delete_context(delete_session_request_t *ds_req,
 			 */
 			si.bearer_id = ds_req->linked_ebi.eps_bearer_id;
 			si.ue_addr.u.ipv4_addr =
-				htonl(pdn->ipv4.s_addr);
+				(pdn->ipv4.s_addr);
 			si.ul_s1_info.sgw_teid =
 				htonl(bearer->s1u_sgw_gtpu_teid);
 			si.sess_id = SESS_ID(
 					context->s11_sgw_gtpc_teid,
 					si.bearer_id);
 			struct dp_id dp_id = { .id = context->dpId };
+			RTE_LOG_DP(INFO, CP, "Sending session delete request with ue IPv4 addr: ");
+			RTE_LOG_DP(INFO, CP, "%d.%d.%d.%d", ((si.ue_addr.u.ipv4_addr >> 24) & 0xFF),
+				((si.ue_addr.u.ipv4_addr >> 16) & 0xFF),
+				((si.ue_addr.u.ipv4_addr >> 8) & 0xFF),
+				((si.ue_addr.u.ipv4_addr & 0xFF)));
 			session_delete(dp_id, si);
 
 			rte_free(pdn->eps_bearers[i]);

--- a/cp/gtpv2c_messages/modify_bearer.c
+++ b/cp/gtpv2c_messages/modify_bearer.c
@@ -184,6 +184,11 @@ process_modify_bearer_request(gtpv2c_header *gtpv2c_rx,
 			context->s11_sgw_gtpc_teid,
 			bearer->eps_bearer_id);
 
+	 RTE_LOG_DP(INFO, CP, "Sending session modify bearer request with ue IPv4 addr: ");
+	 RTE_LOG_DP(INFO, CP, "%d.%d.%d.%d", ((session.ue_addr.u.ipv4_addr >> 24) & 0xFF),
+		((session.ue_addr.u.ipv4_addr >> 16) & 0xFF),
+		((session.ue_addr.u.ipv4_addr >> 8) & 0xFF),
+		((session.ue_addr.u.ipv4_addr & 0xFF)));
 	/* Fetch subscriber using teid and then find the dpId */
 	if (session_modify(dp_id, session) < 0)
 #if defined(ZMQ_COMM) && defined(MULTI_UPFS)

--- a/cp/gtpv2c_messages/release_access_bearer.c
+++ b/cp/gtpv2c_messages/release_access_bearer.c
@@ -99,7 +99,7 @@ process_release_access_bearer_request(gtpv2c_header *gtpv2c_rx,
 		struct session_info session;
 		memset(&session, 0, sizeof(session));
 		session.ue_addr.iptype = IPTYPE_IPV4;
-		session.ue_addr.u.ipv4_addr = ntohl(bearer->pdn->ipv4.s_addr);
+		session.ue_addr.u.ipv4_addr = (bearer->pdn->ipv4.s_addr);
 		session.ul_s1_info.sgw_teid =
 		    ntohl(bearer->s1u_sgw_gtpu_teid);
 		session.ul_s1_info.sgw_addr.iptype = IPTYPE_IPV4;
@@ -107,7 +107,7 @@ process_release_access_bearer_request(gtpv2c_header *gtpv2c_rx,
 		    ntohl(bearer->s1u_sgw_gtpu_ipv4.s_addr);
 		session.ul_s1_info.enb_addr.iptype = IPTYPE_IPV4;
 		session.ul_s1_info.enb_addr.u.ipv4_addr =
-		    ntohl(bearer->s1u_enb_gtpu_ipv4.s_addr);
+		    (bearer->s1u_enb_gtpu_ipv4.s_addr);
 		session.dl_s1_info.enb_teid =
 		    ntohl(bearer->s1u_enb_gtpu_teid);
 		session.dl_s1_info.enb_addr.iptype = IPTYPE_IPV4;
@@ -133,6 +133,11 @@ process_release_access_bearer_request(gtpv2c_header *gtpv2c_rx,
 			sending DP message */
 		resp_t.msg_type = GTP_RELEASE_ACCESS_BEARERS_REQ;
 
+		RTE_LOG_DP(INFO, CP, "Sending session modify release access bearer request with ue IPv4 addr: ");
+		RTE_LOG_DP(INFO, CP, "%d.%d.%d.%d", ((session.ue_addr.u.ipv4_addr >> 24) & 0xFF),
+			((session.ue_addr.u.ipv4_addr >> 16) & 0xFF),
+			((session.ue_addr.u.ipv4_addr >> 8) & 0xFF),
+			((session.ue_addr.u.ipv4_addr & 0xFF)));
 		if (session_modify(dp_id, session) < 0)
 			rte_exit(EXIT_FAILURE,
 				"Bearer Session modify fail !!!");


### PR DESCRIPTION
Fixed messages that would be passed between SPGW-C and UPF.
Replaced an error statement with something more intelligent.

Aether-connected SPGW-C sometimes was showing errors.

Signed-off-by: Muhammad Asim Jamshed <muhammad.jamshed@intel.com>
Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>
Signed-off-by: Hynsun Moon <hyunsun@opennetworking.org>